### PR TITLE
raw_sqlite3: reset returns ok on success

### DIFF
--- a/src/raw_sqlite3.erl
+++ b/src/raw_sqlite3.erl
@@ -247,15 +247,18 @@ bind(Stmt, Params) ->
                    Row     :: tuple().
 %% @doc Evaluate a prepared statement and fetch one result. A statement should
 %% be run till <code>ok</code> is returned.
-%% NOTE: a fully evaluated statement must be reset for re-use in another
-%% operation.
+%% NOTE: a fully evaluated statement is automatically reset if `sqlite3_step` is called
+%% using the statement after it returns `<code>ok</code>`.
 step(Stmt) ->
     expand_error(sqlite3_nif:sqlite3_step(Stmt)).
 
 -spec reset(Stmt::sqlite3_stmt()) -> sqlite3_error_code().
 %% @doc Reset a prepared statement.
 reset(Stmt) ->
-    expand_error(sqlite3_nif:sqlite3_reset(Stmt)).
+    case sqlite3_nif:sqlite3_reset(Stmt) of
+        ?SQLITE_OK -> ok;
+        Err -> expand_error(Err)
+    end.
 
 -spec fetchall(Stmt) -> Result
               when Stmt    :: sqlite3_stmt(),

--- a/test/raw_sqlite3_test.erl
+++ b/test/raw_sqlite3_test.erl
@@ -30,4 +30,12 @@ prepare_statement_test() ->
     ok = raw_sqlite3:exec(Db, "CREATE TABLE t(x INTEGER)"),
     lists:map(fun(Sql) -> ?assertMatch({ok, _}, raw_sqlite3:prepare(Db, Sql)) end, Sqls),
     ?assertMatch({error, _}, raw_sqlite3:prepare(Db, Sql1)).
-   
+
+%% reset should return ok on success
+reset_test() ->
+    Sql1 = "CREATE TABLE t(id INTEGER PRIMARY KEY, txt TEXT)",
+    Sql2 = "SELECT * FROM t",
+    {ok, Db} = raw_sqlite3:open(":memory:"),
+    ok = raw_sqlite3:exec(Db, Sql1),
+    {ok, Stmt} = raw_sqlite3:prepare(Db, Sql2),
+    ?assertEqual(ok, raw_sqlite3:reset(Stmt)).


### PR DESCRIPTION
- Fixes #2 
- Updated doc for `step/1`: you can easily test that prepared statements are in fact automatically reset by calls to `sqlite3_step` subsequent to the latter returning `SQLITE_OK` for a given statement. This is also reflected in the following comments found on line 83608 in sqlite3.c: 
```C
     /* We used to require that sqlite3_reset() be called before retrying
     ** sqlite3_step() after any error or after SQLITE_DONE.  But beginning
     ** with version 3.7.0, we changed this so that sqlite3_reset() would
     ** be called automatically instead of throwing the SQLITE_MISUSE error.
     ** This "automatic-reset" change is not technically an incompatibility,
     ** since any application that receives an SQLITE_MISUSE is broken by
     ** definition.
```
