### PR TITLE
raw_sqlite3: fix close return val

### DIFF
--- a/src/raw_sqlite3.erl
+++ b/src/raw_sqlite3.erl
@@ -192,13 +192,20 @@ open(DbFile, Flags, Vfs) ->
 
 -spec close(Db) -> Result
               when Db     :: sqlite3(),
-                   Result :: sqlite3_error_code().
+                   Result :: ok | {error, sqlite3_error_code()}.
 %% @doc Close database connection.
 %% NOTE: Usually, it is not necessary to call the function because a garbage
 %% collection will destroy the connection object. However, it may be useful to
 %% have the explicit control over a connection handle in some situations.
 close(Db) ->
-    expand_error(sqlite3_nif:sqlite3_close_v2(Db)).
+    case sqlite3_nif:sqlite3_close_v2(Db) of
+        ?SQLITE_OK -> 
+            ok;
+        Err ->
+            {error, expand_error(Err)}
+    end.
+
+
 
 %% @type sqlite3_stmt(). A prepared SQL statement.
 -opaque sqlite3_stmt() :: sqlite3_nif:sqlite3_stmt().
@@ -252,12 +259,12 @@ bind(Stmt, Params) ->
 step(Stmt) ->
     expand_error(sqlite3_nif:sqlite3_step(Stmt)).
 
--spec reset(Stmt::sqlite3_stmt()) -> sqlite3_error_code().
+-spec reset(Stmt::sqlite3_stmt()) -> ok | {error, sqlite3_error_code()}.
 %% @doc Reset a prepared statement.
 reset(Stmt) ->
     case sqlite3_nif:sqlite3_reset(Stmt) of
         ?SQLITE_OK -> ok;
-        Err -> expand_error(Err)
+        Err -> {error, expand_error(Err)}
     end.
 
 -spec fetchall(Stmt) -> Result

--- a/test/raw_sqlite3_test.erl
+++ b/test/raw_sqlite3_test.erl
@@ -31,11 +31,20 @@ prepare_statement_test() ->
     lists:map(fun(Sql) -> ?assertMatch({ok, _}, raw_sqlite3:prepare(Db, Sql)) end, Sqls),
     ?assertMatch({error, _}, raw_sqlite3:prepare(Db, Sql1)).
 
-%% reset should return ok on success
-reset_test() ->
+%% reset should return ok on success and {error, Err} on error
+reset_ret_test() ->
     Sql1 = "CREATE TABLE t(id INTEGER PRIMARY KEY, txt TEXT)",
     Sql2 = "SELECT * FROM t",
+    Sql3 = "DROP TABLE t",
     {ok, Db} = raw_sqlite3:open(":memory:"),
     ok = raw_sqlite3:exec(Db, Sql1),
     {ok, Stmt} = raw_sqlite3:prepare(Db, Sql2),
-    ?assertEqual(ok, raw_sqlite3:reset(Stmt)).
+    ?assertEqual(ok, raw_sqlite3:reset(Stmt)),
+    ok = raw_sqlite3:exec(Db, Sql3),
+    {error, _} = raw_sqlite3:step(Stmt),
+    ?assertMatch({error, _}, raw_sqlite3:reset(Stmt)).
+
+%% close should return ok on success
+close_ret_test() ->
+    {ok, Db} = raw_sqlite3:open(":memory:"),
+    ?assertEqual(ok, raw_sqlite3:close(Db)).


### PR DESCRIPTION
- `close` now returns `ok` or `{error, Err}`, consistent with the rest of the interface. 
- `reset` returns `{error, Err}` in case of error, instead of just `Err`
- Fix spec for `reset`